### PR TITLE
UnitTests added as well as some additional methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Currently supported Models:
 
 Specification from:
 https://www.waveshare.com/w/upload/2/29/7.5inch_e-paper-b-Specification.pdf
+https://www.waveshare.com/w/upload/6/60/7.5inch_e-Paper_V2_Specification.pdf
 
 C Example Code from:
 https://github.com/waveshare/e-Paper/tree/master/RaspberryPi%26JetsonNano/c

--- a/Waveshare.Test/Devices/Epd7In5_V2/Epd7In5_V2Tests.cs
+++ b/Waveshare.Test/Devices/Epd7In5_V2/Epd7In5_V2Tests.cs
@@ -1,0 +1,332 @@
+﻿#region Copyright
+// --------------------------------------------------------------------------------------------------------------------
+// MIT License
+// Copyright(c) 2020 Greg Cannon
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// --------------------------------------------------------------------------------------------------------------------
+#endregion Copyright
+
+#region Usings
+
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Device.Gpio;
+using System.Drawing;
+using System.Linq;
+using Waveshare.Common;
+using Waveshare.Devices.Epd7in5_V2;
+using Waveshare.Interfaces;
+
+#endregion Usings
+
+namespace Waveshare.Test.Devices.Epd7in5_V2
+{
+    public class Epd7In5_V2Tests
+    {
+        private List<byte> m_DataBuffer;
+        private Mock<IEPaperDisplayHardware> m_EPaperDisplayHardwareMock;
+
+        [SetUp]
+        public void Setup()
+        {
+            m_DataBuffer = new List<byte>();
+
+            m_EPaperDisplayHardwareMock = new Mock<IEPaperDisplayHardware>();
+            m_EPaperDisplayHardwareMock.Setup(e => e.BusyPin).Returns(PinValue.High);
+            m_EPaperDisplayHardwareMock.Setup(e => e.WriteByte(It.IsAny<byte>())).Callback((byte b) => m_DataBuffer.Add(b));
+        }
+
+        [Test]
+        public void ConstructorTest()
+        {
+            using var result = new Epd7In5_V2();
+            result.Initialize(m_EPaperDisplayHardwareMock.Object);
+        }
+
+        [Test]
+        public void DisposeNoHardwareTest()
+        {
+            using var result = new Epd7In5_V2();
+            result.Initialize(m_EPaperDisplayHardwareMock.Object);
+        }
+
+        [Test]
+        public void DoubleDisposeTest()
+        {
+            var result = new Epd7In5_V2();
+            result.Initialize(m_EPaperDisplayHardwareMock.Object);
+            result.Dispose();
+            result.Dispose();
+        }
+
+        [Test]
+        public void FinalizerTest()
+        {
+            var result = new Epd7In5_V2();
+            result.Initialize(m_EPaperDisplayHardwareMock.Object);
+
+            Assert.NotNull(result, "Object should not be null");
+
+            // ReSharper disable once RedundantAssignment
+            result = null;
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        [Test]
+        public void FinalizerNoHardwareTest()
+        {
+            var result = new Epd7In5_V2();
+
+            Assert.NotNull(result, "Object should not be null");
+
+            // ReSharper disable once RedundantAssignment
+            result = null;
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+        }
+
+        [Test]
+        public void OnTest()
+        {
+            using var result = new Epd7In5_V2();
+            result.Initialize(m_EPaperDisplayHardwareMock.Object);
+
+            m_DataBuffer.Clear();
+
+            result.On();
+
+            var validBuffer = new List<byte>
+            {
+                (byte)Epd7In5_V2Commands.PowerOn,
+                (byte)Epd7In5_V2Commands.GetStatus
+            };
+            Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
+        }
+
+
+        [Test]
+        public void OffTest()
+        {
+            using var result = new Epd7In5_V2();
+            result.Initialize(m_EPaperDisplayHardwareMock.Object);
+
+            m_DataBuffer.Clear();
+
+            result.Off();
+
+            var validBuffer = new List<byte>
+            {
+                (byte)Epd7In5_V2Commands.PowerOff,
+                (byte)Epd7In5_V2Commands.GetStatus
+            };
+            Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
+        }
+
+
+        [Test]
+        public void SleepTest()
+        {
+            using var result = new Epd7In5_V2();
+            result.Initialize(m_EPaperDisplayHardwareMock.Object);
+
+            m_DataBuffer.Clear();
+
+            result.Sleep();
+
+            var validBuffer = new List<byte>
+            {
+                (byte)Epd7In5_V2Commands.PowerOff,
+                (byte)Epd7In5_V2Commands.GetStatus,
+                (byte)Epd7In5_V2Commands.DeepSleep,
+                0xA5
+            };
+            Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
+        }
+
+        [Test]
+        public void ClearTest()
+        {
+            using var result = new Epd7In5_V2();
+            result.Initialize(m_EPaperDisplayHardwareMock.Object);
+
+            m_DataBuffer.Clear();
+
+            result.Clear();
+
+            const int pixelPerByte = 8;
+            var displayBytes = result.Width / pixelPerByte * result.Height;
+
+            const byte white = 0x00;
+            var eightWhitePixel = EPaperDisplayBase.MergePixelDataInByte(white, white, white, white, white, white, white, white);
+
+            var validBuffer = new List<byte>
+            {
+                (byte) Epd7In5_V2Commands.DataStartTransmission1
+            };
+
+            for (int i = 0; i < displayBytes; i++)
+            {
+                validBuffer.Add(eightWhitePixel);
+            }
+
+            validBuffer.Add((byte)Epd7In5_V2Commands.DataStartTransmission2);
+
+            for (int i = 0; i < displayBytes; i++)
+            {
+                validBuffer.Add(eightWhitePixel);
+            }
+            validBuffer.Add((byte)Epd7In5_V2Commands.DisplayRefresh);
+            validBuffer.Add((byte)Epd7In5_V2Commands.GetStatus);
+
+            Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
+        }
+
+
+        [Test]
+        public void ClearBlackTest()
+        {
+            using var result = new Epd7In5_V2();
+            result.Initialize(m_EPaperDisplayHardwareMock.Object);
+
+            m_DataBuffer.Clear();
+
+            result.ClearBlack();
+
+            const int pixelPerByte = 8;
+            var displayBytes = result.Width / pixelPerByte * result.Height;
+
+            const byte black = 0x01;
+            var eightBlackPixel = EPaperDisplayBase.MergePixelDataInByte(black, black, black, black, black, black, black, black);
+
+            var validBuffer = new List<byte>
+            {
+                (byte) Epd7In5_V2Commands.DataStartTransmission2
+            };
+
+            for (int i = 0; i < displayBytes; i++)
+            {
+                validBuffer.Add(eightBlackPixel);
+            }
+
+            validBuffer.Add((byte)Epd7In5_V2Commands.DisplayRefresh);
+            validBuffer.Add((byte)Epd7In5_V2Commands.GetStatus);
+
+            Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
+        }
+
+        [Test]
+        public void DisplayImageTest()
+        {
+            using var result = new Epd7In5_V2();
+            result.Initialize(m_EPaperDisplayHardwareMock.Object);
+
+            var image = CreateSampleBitmap(result.Width, result.Height);
+
+            m_DataBuffer.Clear();
+
+            result.DisplayImage(image);
+
+            var imageData = result.BitmapToData(image);
+
+            var validBuffer = new List<byte>
+            {
+                (byte) Epd7In5_V2Commands.DataStartTransmission2
+            };
+
+            validBuffer.AddRange(imageData);
+
+            validBuffer.Add((byte)Epd7In5_V2Commands.DataStop);
+            validBuffer.Add((byte)Epd7In5_V2Commands.DisplayRefresh);
+            validBuffer.Add((byte)Epd7In5_V2Commands.GetStatus);
+
+            Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
+        }
+
+        [Test]
+        public void DisplayImageSmallTest()
+        {
+            using var result = new Epd7In5_V2();
+            result.Initialize(m_EPaperDisplayHardwareMock.Object);
+
+            var image = CreateSampleBitmap(result.Width / 2, result.Height / 2);
+
+            m_DataBuffer.Clear();
+
+            result.DisplayImage(image);
+
+            var imageData = result.BitmapToData(image);
+
+            var validBuffer = new List<byte>
+            {
+                (byte) Epd7In5_V2Commands.DataStartTransmission2
+            };
+
+            validBuffer.AddRange(imageData);
+
+            validBuffer.Add((byte)Epd7In5_V2Commands.DataStop);
+            validBuffer.Add((byte)Epd7In5_V2Commands.DisplayRefresh);
+            validBuffer.Add((byte)Epd7In5_V2Commands.GetStatus);
+
+            Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
+        }
+
+        private static Bitmap CreateSampleBitmap(int width, int height)
+        {
+            var image = new Bitmap(width, height);
+
+            for (int y = 0; y < image.Height; y++)
+            {
+                for (int x = 0; x < image.Width; x++)
+                {
+                    var color = Color.White;
+
+                    if (x % 2 == 0)
+                    {
+                        color = Color.Black;
+                    }
+
+                    if (x % 3 == 0)
+                    {
+                        color = Color.Red;
+                    }
+
+                    if (x % 4 == 0)
+                    {
+                        color = Color.Gray;
+                    }
+
+                    if (x % 5 == 0)
+                    {
+                        color = Color.FromArgb(255, 50, 0, 0);
+                    }
+
+                    image.SetPixel(x, y, color);
+                }
+            }
+
+            return image;
+        }
+    }
+}

--- a/Waveshare/Common/EPaperDisplayBase.cs
+++ b/Waveshare/Common/EPaperDisplayBase.cs
@@ -183,9 +183,27 @@ namespace Waveshare.Common
         public abstract void ClearBlack();
 
         /// <summary>
+        /// Power the controller on.  Do not use with SleepMode.
+        /// </summary>
+        public abstract void On();
+
+        /// <summary>
+        /// Power the controler off.  Do not use with SleepMode.
+        /// </summary>
+        public abstract void Off();
+
+        /// <summary>
         /// Send the Display into SleepMode
         /// </summary>
         public abstract void Sleep();
+
+        /// <summary>
+        /// Wake the Display from SleepMode
+        /// </summary>
+        public void Wake()
+        {
+            DeviceInitialize();
+        }
 
         #endregion Public Methods
 

--- a/Waveshare/Devices/Epd7in5_V2/Epd7In5_V2.cs
+++ b/Waveshare/Devices/Epd7in5_V2/Epd7In5_V2.cs
@@ -75,6 +75,20 @@ namespace Waveshare.Devices.Epd7in5_V2
 
         //########################################################################################
 
+        #region Constructor / Dispose / Finalizer
+
+        /// <summary>
+        /// Finalizer
+        /// </summary>
+        ~Epd7In5_V2()
+        {
+            Sleep();
+        }
+
+        #endregion Constructor / Dispose / Finalizer
+
+        //########################################################################################
+
         #region Public Methods
 
         /// <summary>
@@ -97,14 +111,40 @@ namespace Waveshare.Devices.Epd7in5_V2
         }
 
         /// <summary>
+        /// Power the controller on.  Do not use with SleepMode.
+        /// </summary>
+        public override void On()
+        {
+            SendCommand(Epd7In5_V2Commands.PowerOn);
+            WaitUntilReady();
+        }
+
+        /// <summary>
+        /// Power the controler off.  Do not use with SleepMode.
+        /// </summary>
+        public override void Off()
+        {
+            SendCommand(Epd7In5_V2Commands.PowerOff);
+            WaitUntilReady();
+        }
+
+        /// <summary>
         /// Send the Display into SleepMode
         /// </summary>
         public override void Sleep()
         {
-            SendCommand(Epd7In5_V2Commands.PowerOff);
-            WaitUntilReady();
+            Off();
             SendCommand(Epd7In5_V2Commands.DeepSleep);
             SendData(0xA5);
+        }
+
+        /// <summary>
+        /// Wait until the display is ready
+        /// </summary>
+        public new void WaitUntilReady()
+        {
+            base.WaitUntilReady();
+            Thread.Sleep(200);
         }
 
         #endregion Public Methods
@@ -120,9 +160,15 @@ namespace Waveshare.Devices.Epd7in5_V2
         {
             Reset();
 
+            SendCommand(Epd7In5_V2Commands.BoosterSoftStart);
+            SendData(0x17);
+            SendData(0x17);
+            SendData(0x27);
+            SendData(0x17);
+
             SendCommand(Epd7In5_V2Commands.PowerSetting);
             SendData(0x07); // VGH: 20V
-            SendData(0x07); // VGL: -20V
+            SendData(0x17); // VGL: -20V
             SendData(0x3f); // VDH: 15V
             SendData(0x3f); // VDL: -15V
 
@@ -158,15 +204,6 @@ namespace Waveshare.Devices.Epd7in5_V2
             SendCommand(Epd7In5_V2Commands.DisplayRefresh);
             Thread.Sleep(100);
             WaitUntilReady();
-        }
-
-        /// <summary>
-        /// Wait until the display is ready
-        /// </summary>
-        public new void WaitUntilReady()
-        {
-            base.WaitUntilReady();
-            Thread.Sleep(200);
         }
 
         /// <summary>

--- a/Waveshare/Devices/Epd7in5bc/Epd7In5bc.cs
+++ b/Waveshare/Devices/Epd7in5bc/Epd7In5bc.cs
@@ -75,6 +75,20 @@ namespace Waveshare.Devices.Epd7in5bc
 
         //########################################################################################
 
+        #region Constructor / Dispose / Finalizer
+
+        /// <summary>
+        /// Finalizer
+        /// </summary>
+        ~Epd7In5Bc()
+        {
+            Sleep();
+        }
+
+        #endregion Constructor / Dispose / Finalizer
+
+        //########################################################################################
+
         #region Public Methods
 
         /// <summary>
@@ -96,12 +110,29 @@ namespace Waveshare.Devices.Epd7in5bc
         }
 
         /// <summary>
+        /// Power the controller on.  Do not use with SleepMode.
+        /// </summary>
+        public override void On()
+        {
+            SendCommand(Epd7In5BcCommands.PowerOn);
+            WaitUntilReady();
+        }
+
+        /// <summary>
+        /// Power the controler off.  Do not use with SleepMode.
+        /// </summary>
+        public override void Off()
+        {
+            SendCommand(Epd7In5BcCommands.PowerOff);
+            WaitUntilReady();
+        }
+
+        /// <summary>
         /// Send the Display into SleepMode
         /// </summary>
         public override void Sleep()
         {
-            SendCommand(Epd7In5BcCommands.PowerOff);
-            WaitUntilReady();
+            Off();
             SendCommand(Epd7In5BcCommands.DeepSleep);
             SendData(0xA5);
         }

--- a/Waveshare/Interfaces/IEPaperDisplay.cs
+++ b/Waveshare/Interfaces/IEPaperDisplay.cs
@@ -47,14 +47,29 @@ namespace Waveshare.Interfaces
         int Height { get; }
 
         /// <summary>
-        /// Wait until the display is ready
+        /// Wait until the Display is ready
         /// </summary>
         void WaitUntilReady();
+
+        /// <summary>
+        /// Power the controller on.  Do not use with SleepMode.
+        /// </summary>
+        void On();
+
+        /// <summary>
+        /// Power the controler off.  Do not use with SleepMode.
+        /// </summary>
+        void Off();
 
         /// <summary>
         /// Send the Display into SleepMode
         /// </summary>
         void Sleep();
+
+        /// <summary>
+        /// Wake the Display from SleepMode
+        /// </summary>
+        void Wake();
 
         /// <summary>
         /// Clear the Display to White


### PR DESCRIPTION
Hi,

I  added UnitTests for Epd7In5_V2 device.

I also found that if additional images are sent to the e-paper screen at a later time, it is best to power off the screen instead of deep sleep.  Deep sleep clears the "Old" image registers and the screen should be cleared before a new image is sent.  Sending a power off command when you are done with an image, then a power on command before the new image is the proper way to do this and the screen response time is good.  So I added On, Off and Wake methods.  The Wake method basically re-initializes the screen, which I understand is the best practice for coming out of a deep sleep.

I did not add unit tests to your driver for On and Off since I don't know for sure they are work as they are supposed to.  I looked at the specifications for the device and the code should be the same as for the Epd7In5_V2 but you may want to verify functionality first.

Cheers from the United States!

Best regards,
Greg