### PR TITLE
NuGet packages updated and performance changes

### DIFF
--- a/Waveshare.Example/Waveshare.Example.csproj
+++ b/Waveshare.Example/Waveshare.Example.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="1.3.0" />
+    <PackageReference Include="System.Device.Gpio" Version="1.4.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 

--- a/Waveshare.Example/Waveshare.Example.csproj
+++ b/Waveshare.Example/Waveshare.Example.csproj
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="1.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="System.Device.Gpio" Version="1.3.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Waveshare.Test/Devices/Epd7In5_V2/Epd7In5_V2Tests.cs
+++ b/Waveshare.Test/Devices/Epd7In5_V2/Epd7In5_V2Tests.cs
@@ -52,6 +52,7 @@ namespace Waveshare.Test.Devices.Epd7in5_V2
 
             m_EPaperDisplayHardwareMock = new Mock<IEPaperDisplayHardware>();
             m_EPaperDisplayHardwareMock.Setup(e => e.BusyPin).Returns(PinValue.High);
+            m_EPaperDisplayHardwareMock.Setup(e => e.Write(It.IsAny<byte[]>())).Callback((byte[] b) => m_DataBuffer.AddRange(b));
             m_EPaperDisplayHardwareMock.Setup(e => e.WriteByte(It.IsAny<byte>())).Callback((byte b) => m_DataBuffer.Add(b));
         }
 
@@ -87,9 +88,9 @@ namespace Waveshare.Test.Devices.Epd7in5_V2
             Assert.NotNull(result, "Object should not be null");
 
             // ReSharper disable once RedundantAssignment
-            #pragma warning disable IDE0059 // Unnecessary assignment of a value
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             result = null;
-            #pragma warning restore IDE0059 // Unnecessary assignment of a value
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -103,9 +104,9 @@ namespace Waveshare.Test.Devices.Epd7in5_V2
             Assert.NotNull(result, "Object should not be null");
 
             // ReSharper disable once RedundantAssignment
-            #pragma warning disable IDE0059 // Unnecessary assignment of a value
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             result = null;
-            #pragma warning restore IDE0059 // Unnecessary assignment of a value
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -247,22 +248,21 @@ namespace Waveshare.Test.Devices.Epd7in5_V2
 
             var image = CreateSampleBitmap(result.Width, result.Height);
 
-            m_DataBuffer.Clear();
-
-            result.DisplayImage(image);
-
-            var imageData = result.BitmapToData(image);
-
             var validBuffer = new List<byte>
             {
                 (byte) Epd7In5_V2Commands.DataStartTransmission2
             };
 
-            validBuffer.AddRange(imageData);
-
+            m_DataBuffer.Clear();
+            result.BitmapToData(image);
+            validBuffer.AddRange(m_DataBuffer);
             validBuffer.Add((byte)Epd7In5_V2Commands.DataStop);
             validBuffer.Add((byte)Epd7In5_V2Commands.DisplayRefresh);
             validBuffer.Add((byte)Epd7In5_V2Commands.GetStatus);
+
+            m_DataBuffer.Clear();
+
+            result.DisplayImage(image);
 
             Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
         }
@@ -275,22 +275,21 @@ namespace Waveshare.Test.Devices.Epd7in5_V2
 
             var image = CreateSampleBitmap(result.Width / 2, result.Height / 2);
 
-            m_DataBuffer.Clear();
-
-            result.DisplayImage(image);
-
-            var imageData = result.BitmapToData(image);
-
             var validBuffer = new List<byte>
             {
                 (byte) Epd7In5_V2Commands.DataStartTransmission2
             };
 
-            validBuffer.AddRange(imageData);
-
+            m_DataBuffer.Clear();
+            result.BitmapToData(image);
+            validBuffer.AddRange(m_DataBuffer);
             validBuffer.Add((byte)Epd7In5_V2Commands.DataStop);
             validBuffer.Add((byte)Epd7In5_V2Commands.DisplayRefresh);
             validBuffer.Add((byte)Epd7In5_V2Commands.GetStatus);
+
+            m_DataBuffer.Clear();
+
+            result.DisplayImage(image);
 
             Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
         }

--- a/Waveshare.Test/Devices/Epd7in5bc/Epd7In5BcTests.cs
+++ b/Waveshare.Test/Devices/Epd7in5bc/Epd7In5BcTests.cs
@@ -51,6 +51,7 @@ namespace Waveshare.Test.Devices.Epd7in5bc
 
             m_EPaperDisplayHardwareMock = new Mock<IEPaperDisplayHardware>();
             m_EPaperDisplayHardwareMock.Setup(e => e.BusyPin).Returns(PinValue.High);
+            m_EPaperDisplayHardwareMock.Setup(e => e.Write(It.IsAny<byte[]>())).Callback((byte[] b) => m_DataBuffer.AddRange(b));
             m_EPaperDisplayHardwareMock.Setup(e => e.WriteByte(It.IsAny<byte>())).Callback((byte b) => m_DataBuffer.Add(b));
         }
 
@@ -82,13 +83,13 @@ namespace Waveshare.Test.Devices.Epd7in5bc
         {
             var result = new Epd7In5Bc();
             result.Initialize(m_EPaperDisplayHardwareMock.Object);
-            
+
             Assert.NotNull(result, "Object should not be null");
 
             // ReSharper disable once RedundantAssignment
-            #pragma warning disable IDE0059 // Unnecessary assignment of a value
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             result = null;
-            #pragma warning restore IDE0059 // Unnecessary assignment of a value
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -102,9 +103,9 @@ namespace Waveshare.Test.Devices.Epd7in5bc
             Assert.NotNull(result, "Object should not be null");
 
             // ReSharper disable once RedundantAssignment
-            #pragma warning disable IDE0059 // Unnecessary assignment of a value
+#pragma warning disable IDE0059 // Unnecessary assignment of a value
             result = null;
-            #pragma warning restore IDE0059 // Unnecessary assignment of a value
+#pragma warning restore IDE0059 // Unnecessary assignment of a value
 
             GC.Collect();
             GC.WaitForPendingFinalizers();
@@ -243,24 +244,23 @@ namespace Waveshare.Test.Devices.Epd7in5bc
 
             var image = CreateSampleBitmap(result.Width, result.Height);
 
-            m_DataBuffer.Clear();
-
-            result.DisplayImage(image);
-
-            var imageData = result.BitmapToData(image);
-
             var validBuffer = new List<byte>
             {
                 (byte) Epd7In5BcCommands.DataStartTransmission1
             };
 
-            validBuffer.AddRange(imageData);
-
+            m_DataBuffer.Clear();
+            result.BitmapToData(image);
+            validBuffer.AddRange(m_DataBuffer);
             validBuffer.Add((byte)Epd7In5BcCommands.DataStop);
             validBuffer.Add((byte)Epd7In5BcCommands.PowerOn);
             validBuffer.Add((byte)Epd7In5BcCommands.GetStatus);
             validBuffer.Add((byte)Epd7In5BcCommands.DisplayRefresh);
             validBuffer.Add((byte)Epd7In5BcCommands.GetStatus);
+
+            m_DataBuffer.Clear();
+
+            result.DisplayImage(image);
 
             Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
         }
@@ -271,26 +271,25 @@ namespace Waveshare.Test.Devices.Epd7in5bc
             using var result = new Epd7In5Bc();
             result.Initialize(m_EPaperDisplayHardwareMock.Object);
 
-            var image = CreateSampleBitmap(result.Width/2, result.Height/2);
-
-            m_DataBuffer.Clear();
-
-            result.DisplayImage(image);
-
-            var imageData = result.BitmapToData(image);
+            var image = CreateSampleBitmap(result.Width / 2, result.Height / 2);
 
             var validBuffer = new List<byte>
             {
                 (byte) Epd7In5BcCommands.DataStartTransmission1
             };
 
-            validBuffer.AddRange(imageData);
-
+            m_DataBuffer.Clear();
+            result.BitmapToData(image);
+            validBuffer.AddRange(m_DataBuffer);
             validBuffer.Add((byte)Epd7In5BcCommands.DataStop);
             validBuffer.Add((byte)Epd7In5BcCommands.PowerOn);
             validBuffer.Add((byte)Epd7In5BcCommands.GetStatus);
             validBuffer.Add((byte)Epd7In5BcCommands.DisplayRefresh);
             validBuffer.Add((byte)Epd7In5BcCommands.GetStatus);
+
+            m_DataBuffer.Clear();
+
+            result.DisplayImage(image);
 
             Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
         }

--- a/Waveshare.Test/Waveshare.Test.csproj
+++ b/Waveshare.Test/Waveshare.Test.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="System.Device.Gpio" Version="1.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
+    <PackageReference Include="System.Device.Gpio" Version="1.3.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Waveshare.Test/Waveshare.Test.csproj
+++ b/Waveshare.Test/Waveshare.Test.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="System.Device.Gpio" Version="1.3.0" />
+    <PackageReference Include="System.Device.Gpio" Version="1.4.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 

--- a/Waveshare/Common/EPaperDisplayBase.cs
+++ b/Waveshare/Common/EPaperDisplayBase.cs
@@ -272,23 +272,20 @@ namespace Waveshare.Common
         {
             EPaperDisplayHardware.SpiDcPin = PinValue.High;
             EPaperDisplayHardware.SpiCsPin = PinValue.Low;
-            foreach (var dataByte in data)
-            {
-                EPaperDisplayHardware.WriteByte(dataByte);
-            }
+            EPaperDisplayHardware.Write(data);
             EPaperDisplayHardware.SpiCsPin = PinValue.High;
         }
 
         /// <summary>
         /// Check if a Pixel is Monochrom (white, gray or black)
         /// </summary>
-        /// <param name="pixel"></param>
+        /// <param name="r">Red color byte</param>
+        /// <param name="g">Green color byte</param>
+        /// <param name="b">Blue color byte</param>
         /// <returns></returns>
-        protected static bool IsMonochrom(Color pixel)
+        protected static bool IsMonochrom(byte r, byte g, byte b)
         {
-            return pixel.R == pixel.G &&
-                   pixel.R == pixel.B &&
-                   pixel.G == pixel.B;
+            return r == g && g == b;
         }
 
         /// <summary>
@@ -306,7 +303,7 @@ namespace Waveshare.Common
         /// </summary>
         /// <param name="pixel"></param>
         /// <returns>Pixel converted to specific byte value for the hardware</returns>
-        protected abstract byte ColorToByte(Color pixel);
+        protected abstract byte ColorToByte(byte r, byte g, byte b);
 
         #endregion Protected Methods
 

--- a/Waveshare/Common/EPaperDisplayBase.cs
+++ b/Waveshare/Common/EPaperDisplayBase.cs
@@ -181,10 +181,8 @@ namespace Waveshare.Common
         /// <param name="image">Bitmap that should be displayed</param>
         public void DisplayImage(Bitmap image)
         {
-            var data = BitmapToData(image);
-
             SendCommand(StartDataTransmissionCommand);
-            SendData(data);
+            BitmapToData(image);
             SendCommand(StopDataTransmissionCommand);
 
             TurnOnDisplay();
@@ -314,9 +312,8 @@ namespace Waveshare.Common
         /// <summary>
         /// Convert a Bitmap to a Byte Array
         /// </summary>
-        /// <param name="image"></param>
-        /// <returns></returns>
-        internal abstract byte[] BitmapToData(Bitmap image);
+        /// <param name="image">Bitmap to convert</param>
+        internal abstract void BitmapToData(Bitmap image);
 
         /// <summary>
         /// Get the Pixel at position x, y or return a white pixel if it is out of bounds

--- a/Waveshare/Common/EPaperDisplayHardware.cs
+++ b/Waveshare/Common/EPaperDisplayHardware.cs
@@ -180,13 +180,9 @@ namespace Waveshare.Common
         /// Write data to the SPI device
         /// </summary>
         /// <param name="buffer">The buffer that contains the data to be written to the SPI device</param>
-        public void Write(ReadOnlySpan<byte> buffer)
+        public void Write(byte[] buffer)
         {
-            const int maxWrite = 4096;
-            for (int x = 0; x < buffer.Length; x += maxWrite)
-            {
-                SpiDevice?.Write(buffer.Slice(x, Math.Min(maxWrite, buffer.Length - x)));
-            }
+            SpiDevice?.Write(buffer);
         }
 
         /// <summary>

--- a/Waveshare/Common/EPaperDisplayHardware.cs
+++ b/Waveshare/Common/EPaperDisplayHardware.cs
@@ -25,6 +25,7 @@
 
 #region Usings
 
+using System;
 using System.Device.Gpio;
 using System.Device.Spi;
 using Waveshare.Interfaces;
@@ -176,12 +177,25 @@ namespace Waveshare.Common
         #region Public Methods
 
         /// <summary>
-        /// Write a byte to the SPI Bus
+        /// Write data to the SPI device
         /// </summary>
-        /// <param name="data"></param>
-        public void WriteByte(byte data)
+        /// <param name="buffer">The buffer that contains the data to be written to the SPI device</param>
+        public void Write(ReadOnlySpan<byte> buffer)
         {
-            SpiDevice?.WriteByte(data);
+            const int maxWrite = 4096;
+            for (int x = 0; x < buffer.Length; x += maxWrite)
+            {
+                SpiDevice?.Write(buffer.Slice(x, Math.Min(maxWrite, buffer.Length - x)));
+            }
+        }
+
+        /// <summary>
+        /// Write a byte to the SPI device
+        /// </summary>
+        /// <param name="value">The byte to be written to the SPI device</param>
+        public void WriteByte(byte value)
+        {
+            SpiDevice?.WriteByte(value);
         }
 
         #endregion Public Methods
@@ -189,7 +203,6 @@ namespace Waveshare.Common
         //########################################################################################
 
         #region Private Methods
-
         /// <summary>
         /// Create the GPIO Controller
         /// </summary>

--- a/Waveshare/Interfaces/IEPaperDisplayHardware.cs
+++ b/Waveshare/Interfaces/IEPaperDisplayHardware.cs
@@ -59,8 +59,8 @@ namespace Waveshare.Interfaces
         /// Write data to the SPI device
         /// </summary>
         /// <param name="buffer">The buffer that contains the data to be written to the SPI device</param>
-        void Write(ReadOnlySpan<byte> buffer);
-        
+        void Write(byte[] buffer);
+
         /// <summary>
         /// Write a byte to the SPI device
         /// </summary>

--- a/Waveshare/Interfaces/IEPaperDisplayHardware.cs
+++ b/Waveshare/Interfaces/IEPaperDisplayHardware.cs
@@ -56,9 +56,15 @@ namespace Waveshare.Interfaces
         PinValue BusyPin { get; set; }
 
         /// <summary>
-        /// Write a byte to the SPI Bus
+        /// Write data to the SPI device
         /// </summary>
-        /// <param name="data"></param>
-        void WriteByte(byte data);
+        /// <param name="buffer">The buffer that contains the data to be written to the SPI device</param>
+        void Write(ReadOnlySpan<byte> buffer);
+        
+        /// <summary>
+        /// Write a byte to the SPI device
+        /// </summary>
+        /// <param name="value">The byte to be written to the SPI device</param>
+        void WriteByte(byte value);
     }
 }

--- a/Waveshare/Waveshare.csproj
+++ b/Waveshare/Waveshare.csproj
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="1.3.0" />
+    <PackageReference Include="System.Device.Gpio" Version="1.4.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 

--- a/Waveshare/Waveshare.csproj
+++ b/Waveshare/Waveshare.csproj
@@ -22,8 +22,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Device.Gpio" Version="1.0.0" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="System.Device.Gpio" Version="1.3.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
6 NuGet packages were updated the the latest release.
Bitmap read changed to use LockBits for performance.
Display write and clear changed to use buffered write on each image row for performance.
Floyd-Steinberg dithering added for black and white display.
