### PR TITLE
Changed dithering and image writing approach.

### DIFF
--- a/Waveshare.Test/Devices/CommonTestData.cs
+++ b/Waveshare.Test/Devices/CommonTestData.cs
@@ -50,7 +50,7 @@ namespace Waveshare.Test.Devices
         /// <returns></returns>
         public static Bitmap CreateSampleBitmap(int width, int height)
         {
-            var image = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+            var image = new Bitmap(width, height, PixelFormat.Format24bppRgb);
 
             for (int y = 0; y < image.Height; y++)
             {

--- a/Waveshare.Test/Devices/Epd7in5bc/Epd7In5BcTests.cs
+++ b/Waveshare.Test/Devices/Epd7in5bc/Epd7In5BcTests.cs
@@ -31,6 +31,7 @@ using System;
 using System.Collections.Generic;
 using System.Device.Gpio;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using Waveshare.Devices.Epd7in5bc;
 using Waveshare.Image.Bitmap;
@@ -68,6 +69,7 @@ namespace Waveshare.Test.Devices.Epd7in5bc
             m_EPaperDisplayHardwareMock.Setup(e => e.BusyPin).Returns(PinValue.High);
             m_EPaperDisplayHardwareMock.Setup(e => e.Write(It.IsAny<byte[]>())).Callback((byte[] b) => m_DataBuffer.AddRange(b));
             m_EPaperDisplayHardwareMock.Setup(e => e.WriteByte(It.IsAny<byte>())).Callback((byte b) => m_DataBuffer.Add(b));
+            m_EPaperDisplayHardwareMock.Setup(e => e.Write(It.IsAny<MemoryStream>())).Callback((MemoryStream b) => m_DataBuffer.AddRange(b.ToArray()));
         }
 
         #endregion Setup
@@ -284,6 +286,7 @@ namespace Waveshare.Test.Devices.Epd7in5bc
             var bitmapEPaperDisplay = new BitmapLoader(result);
             bitmapEPaperDisplay.DisplayImage(image);
 
+            Assert.AreEqual(validBuffer.Count, m_DataBuffer.Count, "Data Length is wrong");
             Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
         }
 
@@ -314,6 +317,7 @@ namespace Waveshare.Test.Devices.Epd7in5bc
             var bitmapEPaperDisplay = new BitmapLoader(result);
             bitmapEPaperDisplay.DisplayImage(image);
 
+            Assert.AreEqual(validBuffer.Count, m_DataBuffer.Count, "Data Length is wrong");
             Assert.IsTrue(m_DataBuffer.SequenceEqual(validBuffer), "Command Data Sequence is wrong");
         }
 

--- a/Waveshare.Test/Waveshare.Test.csproj
+++ b/Waveshare.Test/Waveshare.Test.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="System.Device.Gpio" Version="1.4.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
   </ItemGroup>

--- a/Waveshare/Common/ByteColor.cs
+++ b/Waveshare/Common/ByteColor.cs
@@ -1,0 +1,96 @@
+﻿#region Copyright
+// --------------------------------------------------------------------------------------------------------------------
+// MIT License
+// Copyright(c) 2021 Greg Cannon
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// --------------------------------------------------------------------------------------------------------------------
+#endregion Copyright
+
+#region Usings
+
+using System;
+
+#endregion Usings
+
+namespace Waveshare.Common
+{
+    /// <summary>
+    /// Structure for holding a three byte color
+    /// </summary>
+    public struct ByteColor : IEquatable<ByteColor>
+    {
+        public byte R { get; private set; }
+        public byte G { get; private set; }
+        public byte B { get; private set; }
+        public bool IsMonochrome { get; private set; }
+
+        public ByteColor(byte red, byte green, byte blue, bool desaturate = false)
+            : this()
+        {
+            R = red;
+            B = blue;
+            G = green;
+            Update(desaturate);
+        }
+
+        public void Desaturate()
+        {
+            if (R != G || G != B)
+            {
+                // Widely established color weights for grayscale
+                const double redWeight = 0.299;
+                const double greenWeight = 0.587;
+                const double blueWeight = 0.114;
+
+                R = (byte)(R * redWeight + G * greenWeight + B * blueWeight + .005);
+                G = R;
+                B = R;
+            }
+        }
+
+        public void SetBGR(byte blue, byte green, byte red, bool desaturate = false)
+        {
+            R = red;
+            B = blue;
+            G = green;
+            Update(desaturate);
+        }
+
+        public override bool Equals(object obj) => obj is ByteColor other && this.Equals(other);
+
+        public bool Equals(ByteColor p) => R == p.R && G == p.G && B == p.B;
+
+        public override int GetHashCode() => (R, G, B).GetHashCode();
+
+        public static bool operator ==(ByteColor lhs, ByteColor rhs) => lhs.Equals(rhs);
+
+        public static bool operator !=(ByteColor lhs, ByteColor rhs) => !lhs.Equals(rhs);
+
+        private void Update(bool desaturate)
+        {
+            IsMonochrome = (R == G && G == B);
+            if (!IsMonochrome && desaturate)
+            {
+                Desaturate();
+                IsMonochrome = true;
+            }
+        }
+    }
+}

--- a/Waveshare/Common/ByteColors.cs
+++ b/Waveshare/Common/ByteColors.cs
@@ -31,23 +31,23 @@ namespace Waveshare.Common
     internal class ByteColors
     {
         /// <summary>
-        /// Color White as ByteArray
+        /// Color White as ByteColor
         /// </summary>
-        public static readonly byte[] White = { 255, 255, 255 };
+        public static readonly ByteColor White = new ByteColor(255, 255, 255);
 
         /// <summary>
-        /// Color Gray as ByteArray
+        /// Color Gray as ByteColor
         /// </summary>
-        public static readonly byte[] Gray = { 128, 128, 128 };
+        public static readonly ByteColor Gray = new ByteColor(128, 128, 128);
 
         /// <summary>
-        /// Color Black as ByteArray
+        /// Color Black as ByteColor
         /// </summary>
-        public static readonly byte[] Black = { 0, 0, 0 };
+        public static readonly ByteColor Black = new ByteColor(0, 0, 0);
 
         /// <summary>
-        /// Color Red as ByteArray
+        /// Color Red as ByteColor
         /// </summary>
-        public static readonly byte[] Red = {255, 0, 0};
+        public static readonly ByteColor Red = new ByteColor(255, 0, 0);
     }
 }

--- a/Waveshare/Common/EPaperDisplayWriter.cs
+++ b/Waveshare/Common/EPaperDisplayWriter.cs
@@ -1,0 +1,187 @@
+﻿#region Copyright
+// --------------------------------------------------------------------------------------------------------------------
+// MIT License
+// Copyright(c) 2021 Greg Cannon
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// --------------------------------------------------------------------------------------------------------------------
+#endregion Copyright
+
+#region Usings
+
+using System;
+using System.IO;
+
+#endregion Usings
+
+namespace Waveshare.Common
+{
+    /// <summary>
+    /// Write image to Waveshare E-Paper Display
+    /// </summary>
+    public class EPaperDisplayWriter : IDisposable
+    {
+        //########################################################################################
+
+        #region Fields
+
+        internal readonly EPaperDisplayBase Display;
+        protected readonly int Width;
+        protected readonly int PixelPerByte;
+        protected readonly int PixelThreshold;
+        protected readonly int StreamThreshold = 4096;
+        protected readonly byte BitShift;
+        protected readonly int WhiteIndex;
+        protected readonly byte[] WhiteLine;
+        private MemoryStream memStream;
+        private byte OutByte;
+        private int m_ByteCount = -1;
+        private bool Disposed = false;
+
+        #endregion Fields
+
+        //########################################################################################
+
+        #region Properties
+
+        protected int ByteCount => m_ByteCount;
+
+        #endregion Properties
+
+        //########################################################################################
+
+        #region Constructor / Dispose / Finalizer
+
+        internal EPaperDisplayWriter(EPaperDisplayBase display)
+        {
+            Display = display;
+            Width = display.Width;
+            PixelPerByte = display.PixelPerByte;
+            BitShift = (byte)(8 / PixelPerByte);
+            PixelThreshold = PixelPerByte - 1;
+            memStream = new MemoryStream();
+            WhiteIndex = display.GetColorIndex(ByteColors.White);
+            WhiteLine = display.GetColoredLineOnDevice(ByteColors.White);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (Disposed)
+            {
+                return;
+            }
+
+            if (disposing && memStream != null)
+            {
+                Finish();
+                memStream.Close();
+                memStream.Dispose();
+                memStream = null;
+            }
+
+            Disposed = true;
+        }
+
+        public virtual void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~EPaperDisplayWriter() => Dispose(false);
+
+        #endregion Constructor / Dispose / Finalizer
+
+        //########################################################################################
+
+        #region Public Methods
+
+        public virtual void Finish()
+        {
+            Flush();
+            OutByte = 0;
+            m_ByteCount = -1;
+        }
+
+        public virtual void Flush()
+        {
+            if (memStream != null && memStream.Length > 0)
+            {
+                memStream.Position = 0;
+                Display.SendData(memStream);
+                memStream.SetLength(0);
+            }
+        }
+
+        public virtual void Write(int index)
+        {
+            byte value = Display.DeviceByteColors[index];
+            m_ByteCount++;
+            if (PixelPerByte == 1)
+            {
+                memStream.WriteByte(value);
+                if (memStream.Length >= StreamThreshold)
+                {
+                    Flush();
+                }
+            }
+            else
+            {
+                OutByte <<= BitShift;
+                OutByte |= value;
+                if (m_ByteCount % PixelPerByte == PixelThreshold)
+                {
+                    memStream.WriteByte(OutByte);
+                    OutByte = 0;
+                    if (memStream.Length >= StreamThreshold)
+                    {
+                        Flush();
+                    }
+                }
+            }
+        }
+
+        public virtual void Write(int[] indexes)
+        {
+            foreach (int index in indexes)
+            {
+                Write(index);
+            }
+        }
+
+        public virtual void WriteBlankLine()
+        {
+            while (PixelPerByte > 1 && m_ByteCount % PixelPerByte != PixelThreshold)
+            {
+                Write(WhiteIndex);
+            }
+
+            memStream.Write(WhiteLine, 0, WhiteLine.Length);
+        }
+
+        public virtual void WriteBlankPixel()
+        {
+            Write(WhiteIndex);
+        }
+
+        #endregion Public Methods
+
+        //########################################################################################
+    }
+}

--- a/Waveshare/Devices/Epd7in5_V2/Epd7In5_V2.cs
+++ b/Waveshare/Devices/Epd7in5_V2/Epd7In5_V2.cs
@@ -25,9 +25,6 @@
 
 #region Usings
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.InteropServices;
 using System.Threading;
 using Waveshare.Common;
 
@@ -46,12 +43,20 @@ namespace Waveshare.Devices.Epd7in5_V2
 
         //########################################################################################
 
+        #region Fields
+
+        private EPaperDisplayWriter m_DisplayWriter;
+
+        #endregion Fields
+
+        //########################################################################################
+
         #region Properties
 
         /// <summary>
         /// Pixels per Byte on the Device
         /// </summary>
-        protected override int PixelPerByte { get; } = 8;
+        public override int PixelPerByte { get; } = 8;
 
         /// <summary>
         /// Pixel Width of the Display
@@ -66,7 +71,17 @@ namespace Waveshare.Devices.Epd7in5_V2
         /// <summary>
         /// Supported Colors of the E-Paper Device
         /// </summary>
-        public override IList<byte[]> SupportedByteColors { get; } = new List<byte[]> { ByteColors.White, ByteColors.Black };
+        public override ByteColor[] SupportedByteColors { get; } = new ByteColor[] { ByteColors.White, ByteColors.Black };
+
+        /// <summary>
+        /// Color Bytes of the E-Paper Device corresponding to the supported colors
+        /// </summary>
+        public override byte[] DeviceByteColors { get; } = new byte[] { 0x00, 0x01 };
+
+        /// <summary>
+        /// Display Writer assigned to the device
+        /// </summary>
+        public override EPaperDisplayWriter DisplayWriter => m_DisplayWriter ?? (m_DisplayWriter = GetDisplayWriter());
 
         /// <summary>
         /// Get Status Command
@@ -81,7 +96,7 @@ namespace Waveshare.Devices.Epd7in5_V2
         /// <summary>
         /// Stop Data Transmission Command
         /// </summary>
-        protected override byte StopDataTransmissionCommand { get; } = (byte)Epd7In5_V2Commands.DataStop;
+        protected override byte StopDataTransmissionCommand { get; } = byte.MaxValue;
 
         #endregion Properties
 
@@ -152,6 +167,18 @@ namespace Waveshare.Devices.Epd7in5_V2
         #region Protected Methods
 
         /// <summary>
+        /// Dispost of instantiated objects
+        /// </summary>
+        /// <param name="disposing"></param>
+        protected override void Dispose(bool disposing)
+        {
+            if (m_DisplayWriter != null)
+            {
+                m_DisplayWriter.Dispose();
+            }
+        }
+
+        /// <summary>
         /// Device specific Initializer
         /// </summary>
         protected override void DeviceInitialize()
@@ -211,14 +238,12 @@ namespace Waveshare.Devices.Epd7in5_V2
         /// <param name="g">Green color byte</param>
         /// <param name="b">Blue color byte</param>
         /// <returns>Pixel converted to specific byte value for the hardware</returns>
-        protected override byte ColorToByte(byte r, byte g, byte b)
+        protected override byte ColorToByte(ByteColor rgb)
         {
-            if (r == g && r == b)
-            {
-                return (byte)(byte.MaxValue - r);
-            }
-
-            return (byte)(byte.MaxValue - (r * 0.299 + g * 0.587 + b * 0.114));
+            if (rgb.R < 128)
+                return 1;
+            else
+                return 0;
         }
 
         #endregion Protected Methods
@@ -227,45 +252,21 @@ namespace Waveshare.Devices.Epd7in5_V2
 
         #region Internal Methods
 
-        /// <summary>
-        /// Send a Bitmap as Byte Array to the Device
-        /// </summary>
-        /// <param name="scanLine">Int Pointer to the start of the Bytearray</param>
-        /// <param name="stride">Length of a ScanLine</param>
-        /// <param name="maxX">Max Pixels horizontal</param>
-        /// <param name="maxY">Max Pixels Vertical</param>
-        internal override void SendBitmapToDevice(IntPtr scanLine, int stride, int maxX, int maxY)
-        {
-            var deviceLineWithInByte = Width * ColorBytesPerPixel;
-            var deviceStep = ColorBytesPerPixel * PixelPerByte;
-
-            var line = new byte[stride];
-
-            for (var y = 0; y < Height; y++)
-            {
-                var outputLine = CloneWhiteScanLine();
-
-                if (y < maxY)
-                {
-                    Marshal.Copy(scanLine, line, 0, line.Length);
-
-                    for (var x = 0; x < deviceLineWithInByte; x += deviceStep)
-                    {
-                        outputLine[x / deviceStep] = GetDevicePixels(x, line);
-                    }
-
-                    scanLine += stride;
-                }
-
-                SendData(outputLine);
-            }
-        }
-
         #endregion
 
         //########################################################################################
 
         #region Private Methods
+
+        /// <summary>
+        /// Generate a display writer for this device
+        /// </summary>
+        /// <returns>Returns a display writer</returns>
+        private EPaperDisplayWriter GetDisplayWriter()
+        {
+            return new EPaperDisplayWriter(this);
+        }
+
 
         /// <summary>
         /// Helper to send a Command based o the Epd7In5_V2Commands Enum
@@ -281,7 +282,7 @@ namespace Waveshare.Devices.Epd7in5_V2
         /// </summary>
         /// <param name="command">Start Data Transmission Command</param>
         /// <param name="rgb">Color to fill the screen</param>
-        private void FillColor(Epd7In5_V2Commands command, byte[] rgb)
+        private void FillColor(Epd7In5_V2Commands command, ByteColor rgb)
         {
             var outputLine = GetColoredLineOnDevice(rgb);
 
@@ -292,6 +293,7 @@ namespace Waveshare.Devices.Epd7in5_V2
                 SendData(outputLine);
             }
         }
+
 
         #endregion Private Methods
 

--- a/Waveshare/Devices/Epd7in5b_V2/Epd7in5b_V2Writer.cs
+++ b/Waveshare/Devices/Epd7in5b_V2/Epd7in5b_V2Writer.cs
@@ -1,0 +1,160 @@
+﻿#region Copyright
+// --------------------------------------------------------------------------------------------------------------------
+// MIT License
+// Copyright(c) 2021 Greg Cannon
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// --------------------------------------------------------------------------------------------------------------------
+#endregion Copyright
+
+#region Usings
+
+using System;
+using System.IO;
+using Waveshare.Common;
+
+#endregion Usings
+
+namespace Waveshare.Devices.Epd7in5b_V2
+{
+    /// <summary>
+    /// Write image to Waveshare 7.5inch e-Paper V2 Black, White and Red Display
+    /// </summary>
+    internal class Epd7in5b_V2Writer : EPaperDisplayWriter
+    {
+        //########################################################################################
+
+        #region Fields
+
+        private readonly int RedIndex;
+        private readonly byte RedPixel;
+        private readonly int BlackIndex;
+        private readonly byte BlackPixel;
+        private readonly byte[] BlackLine;
+        private MemoryStream memStream;
+        private byte OutByte;
+        private bool Disposed = false;
+
+        #endregion Fields
+
+        //########################################################################################
+
+        #region Constructor / Dispose / Finalizer
+
+        internal Epd7in5b_V2Writer(EPaperDisplayBase display) 
+            : base (display)
+        {
+            memStream = new MemoryStream();
+            RedIndex = display.GetColorIndex(ByteColors.Red);
+            RedPixel = display.DeviceByteColors[RedIndex];
+            BlackIndex = display.GetColorIndex(ByteColors.Black);
+            BlackPixel = display.DeviceByteColors[BlackIndex];
+            BlackLine = display.GetColoredLineOnDevice(ByteColors.Black);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            if (Disposed)
+            {
+                return;
+            }
+
+            if (disposing && memStream != null)
+            {
+                Finish();
+                memStream.Close();
+                memStream.Dispose();
+                memStream = null;
+            }
+
+            Disposed = true;
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~Epd7in5b_V2Writer() => Dispose(false);
+
+        #endregion Constructor / Dispose / Finalizer
+
+        //########################################################################################
+
+        #region Public Methods
+
+        public override void Finish()
+        {
+            base.Finish();
+            if (memStream.Length > 0)
+            {
+                Display.SendCommand((byte)Epd7In5b_V2Commands.DataStartTransmission2);
+                memStream.Position = 0;
+                Display.SendData(memStream);
+            }
+            OutByte = 0;
+        }
+
+        public override void Write(int index)
+        {
+            byte value;
+            if (index == RedIndex)
+            {
+                base.Write(BlackIndex);
+                value = RedPixel;
+            }
+            else
+            {
+                base.Write(index);
+                value = BlackPixel;
+            }
+
+            if (PixelPerByte == 1)
+            {
+                memStream.WriteByte(value);
+            }
+            else
+            {
+                OutByte <<= BitShift;
+                OutByte |= value;
+                if (ByteCount % PixelPerByte == PixelThreshold)
+                {
+                    memStream.WriteByte(OutByte);
+                    OutByte = 0;
+                }
+            }
+        }
+
+        public override void WriteBlankLine()
+        {
+            while (PixelPerByte > 1 && ByteCount % PixelPerByte != PixelThreshold)
+            {
+                Write(WhiteIndex);
+            }
+
+            memStream.Write(BlackLine, 0, BlackLine.Length);
+            base.WriteBlankLine();
+        }
+
+        #endregion Public Methods
+    }
+}

--- a/Waveshare/Image/Bitmap/BitmapLoader.cs
+++ b/Waveshare/Image/Bitmap/BitmapLoader.cs
@@ -56,7 +56,7 @@ namespace Waveshare.Image.Bitmap
         /// <summary>
         /// Bitmap Dithering Helper
         /// </summary>
-        private BitmapDithering BitmapDithering => m_BitmapDithering ?? (m_BitmapDithering = new BitmapDithering(SupportedByteColors));
+        // private BitmapDithering BitmapDithering => m_BitmapDithering ?? (m_BitmapDithering = new BitmapDithering(SupportedByteColors));
         
         #endregion Properties
 
@@ -79,7 +79,7 @@ namespace Waveshare.Image.Bitmap
         #region Protected Methods
 
         /// <summary>
-        /// Load the SSystem.Drawing.Bitmap into a RAWImage
+        /// Load the System.Drawing.Bitmap into a RawImage
         /// </summary>
         /// <param name="image"></param>
         /// <returns></returns>
@@ -96,11 +96,11 @@ namespace Waveshare.Image.Bitmap
         /// </summary>
         /// <param name="image"></param>
         /// <returns></returns>
-        protected override IRawImage LoadImageWithDithering(System.Drawing.Bitmap image)
-        {
-            var ditheredBitmap = BitmapDithering.Dither(image);
-            return LoadImage(ditheredBitmap);
-        }
+        //protected override IRawImage LoadImageWithDithering(System.Drawing.Bitmap image)
+        //{
+        //    var ditheredBitmap = BitmapDithering.Dither(image);
+        //    return LoadImage(ditheredBitmap);
+        //}
 
         #endregion Protected Methods
 

--- a/Waveshare/Image/Bitmap/BitmapRawImage.cs
+++ b/Waveshare/Image/Bitmap/BitmapRawImage.cs
@@ -42,6 +42,14 @@ namespace Waveshare.Image.Bitmap
 
         //########################################################################################
 
+        #region Fields
+
+        private bool Disposed = false;
+
+        #endregion Fields
+
+        //########################################################################################
+
         #region Properties
 
         /// <summary>
@@ -117,15 +125,33 @@ namespace Waveshare.Image.Bitmap
         /// <summary>
         /// Dispose
         /// </summary>
+        public void Dispose(bool disposing)
+        {
+            if (Disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                Bitmap?.UnlockBits(BitmapData);
+                BitmapData = null;
+                m_ScanLine = IntPtr.Zero;
+
+                Bitmap?.Dispose();
+                Bitmap = null;
+            }
+
+            Disposed = true;
+        }
+
         public void Dispose()
         {
-            Bitmap?.UnlockBits(BitmapData);
-            BitmapData = null;
-            m_ScanLine = IntPtr.Zero;
-
-            Bitmap?.Dispose();
-            Bitmap = null;
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
+
+        ~BitmapRawImage() => Dispose(false);
 
         #endregion Constructor / Dispose / Finalizer
 

--- a/Waveshare/Image/EPaperImageBase.cs
+++ b/Waveshare/Image/EPaperImageBase.cs
@@ -26,7 +26,7 @@
 #region Usings
 
 using System;
-using System.Collections.Generic;
+using Waveshare.Common;
 using Waveshare.Interfaces;
 
 #endregion Usings
@@ -62,7 +62,7 @@ namespace Waveshare.Image
         /// <summary>
         /// Supported Colors of the E-Paper Device
         /// </summary>
-        protected IList<byte[]> SupportedByteColors => EPaperDisplay.SupportedByteColors;
+        protected ByteColor[] SupportedByteColors => EPaperDisplay.SupportedByteColors;
 
         #endregion Properties
 
@@ -164,9 +164,9 @@ namespace Waveshare.Image
         public void Reset() => EPaperDisplay.Reset();
 
         /// <summary>
-        /// Display a Image on the Display
+        /// Display an Image on the Display
         /// </summary>
-        /// <param name="image">Image that should be displayed</param>
+        /// <param name="image">Image to be displayed</param>
         /// <param name="dithering">Use Dithering</param>
         public void DisplayImage(T image, bool dithering)
         {
@@ -181,28 +181,28 @@ namespace Waveshare.Image
         }
 
         /// <summary>
-        /// Display a Image on the Display
+        /// Display an Image on the Display
         /// </summary>
-        /// <param name="image">Image that should be displayed</param>
+        /// <param name="image">Image to be displayed</param>
         public void DisplayImage(T image)
         {
             using (var rawImage = LoadImage(image))
             {
                 EPaperDisplay.ColorBytesPerPixel = rawImage.BytesPerPixel;
-                EPaperDisplay.DisplayImage(rawImage);
+                EPaperDisplay.DisplayImage(rawImage, false);
             }
         }
 
         /// <summary>
         /// Display Image of a generic Type with dithering
         /// </summary>
-        /// <param name="image">Image that should be displayed</param>
+        /// <param name="image">Image to be displayed</param>
         public void DisplayImageWithDithering(T image)
         {
-            using (var rawImage = LoadImageWithDithering(image))
+            using (var rawImage = LoadImage(image))
             {
                 EPaperDisplay.ColorBytesPerPixel = rawImage.BytesPerPixel;
-                EPaperDisplay.DisplayImage(rawImage);
+                EPaperDisplay.DisplayImage(rawImage, true);
             }
         }
 
@@ -224,7 +224,7 @@ namespace Waveshare.Image
         /// </summary>
         /// <param name="image"></param>
         /// <returns></returns>
-        protected abstract IRawImage LoadImageWithDithering(T image);
+        //protected abstract IRawImage LoadImageWithDithering(T image);
 
         #endregion Protected Methods
 

--- a/Waveshare/Interfaces/IEPaperDisplayHardware.cs
+++ b/Waveshare/Interfaces/IEPaperDisplayHardware.cs
@@ -26,6 +26,7 @@
 #region Usings
 using System;
 using System.Device.Gpio;
+using System.IO;
 #endregion Usings
 
 namespace Waveshare.Interfaces
@@ -54,6 +55,12 @@ namespace Waveshare.Interfaces
         /// GPIO Busy Pin
         /// </summary>
         PinValue BusyPin { get; set; }
+
+        /// <summary>
+        /// Write data to the SPI device
+        /// </summary>
+        /// <param name="stream">The stream that contains the data to be written to the SPI device</param>
+        void Write(MemoryStream stream);
 
         /// <summary>
         /// Write data to the SPI device

--- a/Waveshare/Interfaces/IEPaperDisplayInternal.cs
+++ b/Waveshare/Interfaces/IEPaperDisplayInternal.cs
@@ -23,8 +23,7 @@
 // --------------------------------------------------------------------------------------------------------------------
 #endregion Copyright
 
-using System;
-using System.Collections.Generic;
+using Waveshare.Common;
 
 namespace Waveshare.Interfaces
 {
@@ -41,7 +40,7 @@ namespace Waveshare.Interfaces
         /// <summary>
         /// Supported Colors of the E-Paper Device
         /// </summary>
-        IList<byte[]> SupportedByteColors { get; }
+        ByteColor[] SupportedByteColors { get; }
 
         /// <summary>
         /// E-Paper Hardware Interface for GPIO and SPI Bus
@@ -58,6 +57,6 @@ namespace Waveshare.Interfaces
         /// Display a Image on the Display
         /// </summary>
         /// <param name="rawImage">Bitmap that should be displayed</param>
-        void DisplayImage(IRawImage rawImage);
+        void DisplayImage(IRawImage rawImage, bool dithering);
     }
 }


### PR DESCRIPTION
Updates to disposing
Fixed issues with Ebd7in5b_V2 Tests
Commented out loading with dithering
Added a struct for colors (red, green and blue)
Added a color to device byte mapping method that finds the closest color
Added color dithering while writing
Added a DisplayWriter to simplify and standarize image writing
Added a Epd7in5b_V2Writer which extends the DisplayWriter to handle the writing of two separate images, one for Black/White and one for Red